### PR TITLE
Update CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@ else (NOT (MSVC))
 endif ()
 
 find_library(FLAC++_LIBRARIES NAMES FLAC++ FLAC)
-find_library(OGG NAMES OGG)
+find_library(ogg NAMES ogg)
 
 add_executable(${PROJECT_NAME} main.cc)
-target_link_libraries(${PROJECT_NAME} FLAC++ FLAC OGG)
+target_link_libraries(${PROJECT_NAME} FLAC++ FLAC ogg)


### PR DESCRIPTION
In Ubuntu 20.09 and Fedora 33, while building, following error occurs:

[ 50%] Linking CXX executable MQA_identifier
/usr/bin/ld: cannot find -lOGG
collect2: error: ld returned 1 exit status
make[2]: *** [CMakeFiles/MQA_identifier.dir/build.make:103: MQA_identifier] error 1
make[1]: *** [CMakeFiles/Makefile2:95: CMakeFiles/MQA_identifier.dir/all] erro 2
make: *** [Makefile:103: all] error 2

Even after installing libogg-dev or libogg-devel.
This can be fixed by changing OGG into ogg. I think this is a problem related with ogg library name(consisted of lowercase characters).
I have little knowledge about cmake, so this may lead to another problem, but at least on my machines it worked fine.
Sorry for poor english.